### PR TITLE
Remove ens references & add info tooltip when user can not stake

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -251,6 +251,13 @@ export default function Home() {
       utils.formatUnits(minimumStake, 'ether') &&
     !ethers.utils.isAddress(cohortAddress);
 
+  const canNotStakeTooltipLabel = !ethers.utils.isAddress(cohortAddress)
+    ? 'Please input a valid wallet address'
+    : utils.formatUnits(allowance, 'ether') <
+      utils.formatUnits(minimumStake, 'ether')
+    ? 'Allowance is smaller than the minimum stake amount.'
+    : 'Your RAID balance is too low';
+
   return (
     <Flex
       minH='350px'
@@ -401,15 +408,7 @@ export default function Home() {
                   </StyledButton>
                   <Tooltip
                     isDisabled={canStake}
-                    label={
-                      utils.formatUnits(allowance, 'ether') <
-                      utils.formatUnits(minimumStake, 'ether')
-                        ? 'Allowance is smaller than the minimum stake amount.'
-                        : utils.formatUnits(raidBalance, 'ether') <
-                          utils.formatUnits(minimumStake, 'ether')
-                        ? 'Your RAID balance is too low'
-                        : 'Please input a valid wallet address'
-                    }
+                    label={canNotStakeTooltipLabel}
                     shouldWrapChildren
                   >
                     <StyledButton


### PR DESCRIPTION
Wrote a little helper that checks whether the user can't stake and another helper that defines the tooltip info message that explains why they can not stake.

![Screenshot 2022-08-26 at 10 31 11](https://user-images.githubusercontent.com/35112939/186859363-247b536c-8da1-40c4-98a8-295d4d4fa929.png)
![Screenshot 2022-08-26 at 10 31 17](https://user-images.githubusercontent.com/35112939/186859345-21554af3-37e6-4519-8056-bd90a80fbd32.png)

Closes #25 